### PR TITLE
add initial templates and config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Did something not work as expected?
+title: "fix: [what is the issue?] in [where is the issue?]"
+labels: ["status : need-investigation", "issue : bug"]
+---
+
+<!---
+Thanks for filing an issue! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have reported the same issue before.
+-->
+
+# Bug Report
+<!--- Provide a general summary of the issue here -->
+
+## Repro or Code Sample
+<!-- Please provide steps to reproduce the issue and/or a code repository, gist, code snippet or sample files -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+<!--- If you are seeing an error, please include the full error message and stack trace -->
+<!--- If applicable, provide screenshots -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+<!--- Please let us know if you'd be willing to contribute the fix; we'd be happy to work with you -->
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details as possible about the environment you experienced the bug in -->
+
+* OS & Device: [e.g. MacOS, iOS, Windows, Linux] on [iPhone 7, PC]
+* Browser [e.g. Microsoft Edge, Google Chrome, Apple Safari, Mozilla FireFox]
+* Version [e.g. 1.8.0]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Have a Question?
+    url: https://github.com/trans-stat/tas-project-example/discussions/new?category=q-a
+    about: Open a new Q&A discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: Have an idea for a new feature?
+title: "feat: add [what] to/in [where]"
+labels: ['status : need-investigation']
+---
+
+<!---
+Thanks for filing an issue! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have requested the same feature before.
+-->
+
+# Feature Request
+<!--- Provide a general summary of the feature here -->
+
+## Expected Behavior
+<!--- Tell us how the feature should work -->
+
+## Current Behavior
+<!--- Explain how the feature would alter/enhance current behavior -->
+
+## Possible Solution
+<!--- Ideas how to implement this feature -->
+<!--- What implementation solution would be ideal for you? -->
+
+## Context
+<!--- What are you trying to accomplish? -->
+<!--- How has not having this feature affected you? -->
+<!--- What alternatives have you considered? -->
+
+## Examples
+<!-- Examples help us understand the requested feature better -->
+<!-- Attach screenshots or images if they would add detail to your request -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!---
+Thanks for filing a pull request! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have pushed the same thing before!
+
+Provide a summary of your changes in the title field above.
+-->
+
+# Pull Request
+
+## Description
+
+<!---
+Provide some background and a description of your work.
+What problem does this change solve?
+Is this a breaking change, chore, fix, feature, etc?
+-->
+
+### Issues
+
+<!---
+* List and link relevant issues here.
+-->
+
+## Reviewer Notes
+
+<!---
+Provide some notes for reviewers to help them provide targeted feedback and testing.
+
+Do you recommend a smoke test for this PR? What steps should be followed?
+Are there particular areas of the code the reviewer should focus on?
+-->
+
+## Test Plan
+
+<!---
+Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
+-->
+
+## Checklist
+
+### General
+
+<!--- Review the list and put an x in the boxes that apply. -->
+
+- [ ] I have added tests for my changes.
+- [ ] I have tested my changes.
+- [ ] I have updated the project documentation to reflect my changes.
+
+## Next Steps
+
+<!---
+If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
+-->


### PR DESCRIPTION
Adding templates for bug report and feature request. We can look into other templates like RFC down the road as needed. This PR also includes a PR template and config for the issue chooser.

closes #1 